### PR TITLE
Hotfix proposal for HUGE coordinates and velocity values when generating the .gcode file

### DIFF
--- a/3MeloD.py
+++ b/3MeloD.py
@@ -83,7 +83,7 @@ def kinematics(speed: float, this_note: str, last_note: str, dim: float, current
     global tempo
 
     mid_pos: float = dim/2
-    move_length: float = speed / (60 / (tempo * subdivision))
+    move_length: float = speed / (tempo * subdivision)
 
     if this_note != last_note:  # different note being played - move towards middle of axis
         if current_pos <= mid_pos:
@@ -117,7 +117,7 @@ def kinematics(speed: float, this_note: str, last_note: str, dim: float, current
 # takes in x, y, and z distances, finds speed of combined move
 def vector_finder(x_: float, y_: float, z_: float) -> float:
     vec_length: float = math.sqrt(x_ ** 2 + y_ ** 2 + z_ ** 2)
-    return vec_length / (60 / (tempo * subdivision))
+    return vec_length * tempo * subdivision
 
 
 

--- a/3MeloD.py
+++ b/3MeloD.py
@@ -12,7 +12,7 @@ if not project_config.could_load_file(config_default_name):
     print(f"failed to load \"{config_default_name}\" file")
     exit(-1)
 
-# assume 60 beats per minute, that means 60 quarter notes per second,
+# multiplies tempo by subdivision - subdivision of 4 = 4x tempo effectively treating quarter notes (common time) as sixteenth notes
 subdivision: float = 4 # quarter = 1, eighth = 2, sixteenth = 4
 
 ##### Inputs #####
@@ -117,7 +117,7 @@ def kinematics(speed: float, this_note: str, last_note: str, dim: float, current
 # takes in x, y, and z distances, finds speed of combined move
 def vector_finder(x_: float, y_: float, z_: float) -> float:
     vec_length: float = math.sqrt(x_ ** 2 + y_ ** 2 + z_ ** 2)
-    return vec_length * tempo * subdivision
+    return vec_length / (tempo * subdivision)
 
 
 


### PR DESCRIPTION
This PR tries to solve some errors regarding the generation of the `.gcode` code values for the songs, as it is shown in the following image:

![imagen](https://github.com/user-attachments/assets/d03424d2-636a-42bd-b3bc-e2f97abd24da)
 
The new `.gcode` file has some values that are too big, and it may cause some troubles when trying to play it (in the best scenario, it would stop, but i'm not sure if the gcode internal interpretation does have some kind of protection against big values).


##  The explanation i came up with

 >Before keep going, i want to make clear that this is my intepretation of what and why the values were obtained the way it is, and the base reasoning used for the patching code. 
As the proposed fix seems to work and reproduce the same values again, this following explanation may be wrong/incorrect, and the patching code may seem counter-intuitive at first

It seems to be related with the usage of the new `subdivision` variable (i think i remember that the `subdivision` variable is related with the previous magic numbers 60 and 15) in the following places:
### **Inside the `kinematics` function**

#### Before the `subdivision` variable usage
The `move_length` variable was obtained by the following code and formula: 

![imagen](https://github.com/user-attachments/assets/961a8b40-0c8b-449a-974e-96193b824734)

$$
\frac{speed}{60} * \frac{15}{tempo} = \frac{speed}{tempo * 4}
$$

#### Current `subdivision` variable usage
The formula now it is as follows: 

$$
\frac{speed}{60 / (tempo * subdivision)} = \frac{speed}{60 / (tempo * 4)} = \frac{speed * tempo * 4}{60} = \frac{speed * tempo}{15}
$$

#### Proposed fix
The proposed fix restores the initial formula as follows:

$$
\frac{speed}{tempo * subdivision} = \frac{speed}{tempo * 4}
$$

### **Inside the `vector_finder` function**

#### Before the `subdivision` variable usage
Using the same analysis, the value returned in the `vector_finder` function was as shown:

![imagen](https://github.com/user-attachments/assets/38860f06-c0f7-43b8-a5fa-924768f6af06)

$$
\frac{vec_{length}}{15 * tempo} * 60 = \frac{vec_{length} * tempo}{15} * 60 = vec_{length} * tempo * 4
$$

#### Current `subdivision` variable usage
Then, the current code used this other formula:

$$
\frac{vec_{length}}{60 / (tempo * subdivision)} = \frac{vec_{length} * tempo * subdivision}{60} = \frac{vec_{length} * tempo * 4}{60} = \frac{vec_{length} * tempo}{15}
$$

#### Proposed fix
The proposed fix restores the initial formula as follows:

$$
vec_{length} * tempo * subdivision = vec_{length} * tempo * 4
$$